### PR TITLE
fix crash caused by passing non ansi path to std::filesystem functions

### DIFF
--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -91,21 +91,25 @@ bool CopyFile(const std::string& srcFilename, const std::string& dstFilename, bo
   return false;
 }
 
-std::filesystem::path ConvertToPlatformPath(const std::string& path) {
-  std::string normalizedPath = NormalizePath(path);
+std::string ConvertToPlatformPath(const std::string& path) {
+    std::string normalizedPath = NormalizePath(path);
 
 #ifdef _WIN32
-    // Windows: UTF-8 (std::string) to UTF-16 (std::wstring)
+    // Step 1: Convert UTF-8 (std::string) to UTF-16 (std::wstring)
     int size_needed = MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, nullptr, 0);
     if (size_needed == 0) return {};
 
     std::wstring wPath(size_needed, 0);
     MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, &wPath[0], size_needed);
 
-    return std::filesystem::path(wPath);
+    // Step 2: Convert std::wstring to std::filesystem::path
+    std::filesystem::path fsPath(wPath);
+
+    // Step 3: Convert back to std::string (UTF-8)
+    return fsPath.string();
 #else
     // Linux/macOS use UTF-8 directly
-    return std::filesystem::path(normalizedPath);
+    return std::filesystem::path(normalizedPath).string();
 #endif
 }
 

--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -18,7 +18,6 @@
 
 #ifdef _WIN32
 #define NOMINMAX
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -93,7 +92,7 @@ bool CopyFile(const std::string& srcFilename, const std::string& dstFilename, bo
   return false;
 }
 
-std::string ConvertToPlatformPath(const std::string& path) {
+std::filesystem::path ConvertToPlatformPath(const std::string& path) {
     std::string normalizedPath = NormalizePath(path);
 
 #ifdef _WIN32
@@ -105,13 +104,10 @@ std::string ConvertToPlatformPath(const std::string& path) {
     MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, &wPath[0], size_needed);
 
     // Step 2: Convert std::wstring to std::filesystem::path
-    std::filesystem::path fsPath(wPath);
-
-    // Step 3: Convert back to std::string (UTF-8)
-    return fsPath.string();
+    return std::filesystem::path(wPath);
 #else
     // Linux/macOS use UTF-8 directly
-    return std::filesystem::path(normalizedPath).string();
+    return std::filesystem::path(normalizedPath);
 #endif
 }
 

--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -16,6 +16,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "FBX2glTF.h"
 #include "String_Utils.hpp"
 
@@ -86,4 +90,23 @@ bool CopyFile(const std::string& srcFilename, const std::string& dstFilename, bo
       srcSize);
   return false;
 }
+
+std::filesystem::path ConvertToPlatformPath(const std::string& path) {
+  std::string normalizedPath = NormalizePath(path);
+
+#ifdef _WIN32
+    // Windows: UTF-8 (std::string) to UTF-16 (std::wstring)
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, nullptr, 0);
+    if (size_needed == 0) return {};
+
+    std::wstring wPath(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, &wPath[0], size_needed);
+
+    return std::filesystem::path(wPath);
+#else
+    // Linux/macOS use UTF-8 directly
+    return std::filesystem::path(normalizedPath);
+#endif
+}
+
 } // namespace FileUtils

--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -92,23 +92,4 @@ bool CopyFile(const std::string& srcFilename, const std::string& dstFilename, bo
   return false;
 }
 
-std::filesystem::path ConvertToPlatformPath(const std::string& path) {
-    std::string normalizedPath = NormalizePath(path);
-
-#ifdef _WIN32
-    // Step 1: Convert UTF-8 (std::string) to UTF-16 (std::wstring)
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, nullptr, 0);
-    if (size_needed == 0) return {};
-
-    std::wstring wPath(size_needed, 0);
-    MultiByteToWideChar(CP_UTF8, 0, normalizedPath.c_str(), -1, &wPath[0], size_needed);
-
-    // Step 2: Convert std::wstring to std::filesystem::path
-    return std::filesystem::path(wPath);
-#else
-    // Linux/macOS use UTF-8 directly
-    return std::filesystem::path(normalizedPath);
-#endif
-}
-
 } // namespace FileUtils

--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -17,6 +17,8 @@
 #include <stdio.h>
 
 #ifdef _WIN32
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
+#include <filesystem>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
-#include <optional>
-#include <filesystem>
 
 namespace FileUtils {
 
@@ -32,20 +32,18 @@ bool CopyFile(
     const std::string& dstFilename,
     bool createPath = false);
 
-std::filesystem::path ConvertToPlatformPath(const std::string& path);
-
 inline std::string NormalizePath(const std::string& path) {
 #ifdef __APPLE__
-    std::string normalizedPath = path;
-    std::replace(normalizedPath.begin(), normalizedPath.end(), '\\', '/');
-    return normalizedPath;
+  std::string normalizedPath = path;
+  std::replace(normalizedPath.begin(), normalizedPath.end(), '\\', '/');
+  return normalizedPath;
 #else
-    return path;
+  return path;
 #endif
 }
 
 inline std::string GetAbsolutePath(const std::string& filePath) {
-  std::filesystem::path path = ConvertToPlatformPath(filePath);
+  std::filesystem::path path(filePath);
   std::filesystem::path absolutePath = std::filesystem::absolute(path);
   return absolutePath.string();
 }
@@ -55,33 +53,33 @@ inline std::string GetCurrentFolder() {
 }
 
 inline bool FileExists(const std::string& filePath) {
-  std::filesystem::path path = ConvertToPlatformPath(filePath);
+  std::filesystem::path path(filePath);
   std::error_code errorCode;
   return std::filesystem::exists(path, errorCode) && std::filesystem::is_regular_file(path, errorCode);
 }
 
 inline bool FolderExists(const std::string& path) {
-  std::filesystem::path platformPath = ConvertToPlatformPath(path);
+  std::filesystem::path fdPath(path);
   std::error_code errorCode;
-  return std::filesystem::exists(platformPath, errorCode) && std::filesystem::is_directory(platformPath, errorCode);
+  return std::filesystem::exists(fdPath, errorCode) && std::filesystem::is_directory(fdPath, errorCode);
 }
 
 inline std::string getFolder(const std::string& path) {
-  return ConvertToPlatformPath(path).parent_path().string();
+  return std::filesystem::path(path).parent_path().string();
 }
 
 inline std::string GetFileName(const std::string& filePath) {
-  return ConvertToPlatformPath(filePath).filename().string();
+  return std::filesystem::path(filePath).filename().string();
 }
 
 inline std::string GetFileBase(const std::string& filePath) {
-  return ConvertToPlatformPath(filePath).stem().string();
+  return std::filesystem::path(filePath).stem().string();
 }
 
 inline std::optional<std::string> GetFileSuffix(const std::string& filePath) {
-  std::filesystem::path platformPath = ConvertToPlatformPath(filePath);
+  std::filesystem::path path(filePath);
 
-  const auto& extension = platformPath.extension();
+  const auto& extension = path.extension();
   if (extension.empty()) {
     return std::nullopt;
   }

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -32,7 +32,7 @@ bool CopyFile(
     const std::string& dstFilename,
     bool createPath = false);
 
-std::filesystem::path ConvertToPlatformPath(const std::string& path);
+std::string ConvertToPlatformPath(const std::string& path);
 
 inline std::string NormalizePath(const std::string& path) {
 #ifdef __APPLE__

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -32,7 +32,7 @@ bool CopyFile(
     const std::string& dstFilename,
     bool createPath = false);
 
-std::string ConvertToPlatformPath(const std::string& path);
+std::filesystem::path ConvertToPlatformPath(const std::string& path);
 
 inline std::string NormalizePath(const std::string& path) {
 #ifdef __APPLE__
@@ -45,7 +45,8 @@ inline std::string NormalizePath(const std::string& path) {
 }
 
 inline std::string GetAbsolutePath(const std::string& filePath) {
-  std::filesystem::path absolutePath = std::filesystem::absolute(ConvertToPlatformPath(filePath));
+  std::filesystem::path path = ConvertToPlatformPath(filePath);
+  std::filesystem::path absolutePath = std::filesystem::absolute(path);
   return absolutePath.string();
 }
 
@@ -54,31 +55,31 @@ inline std::string GetCurrentFolder() {
 }
 
 inline bool FileExists(const std::string& filePath) {
-  std::string platformPath = ConvertToPlatformPath(filePath);
-  return std::filesystem::exists(platformPath) && std::filesystem::is_regular_file(platformPath);
+  std::filesystem::path path = ConvertToPlatformPath(filePath);
+  return std::filesystem::exists(path) && std::filesystem::is_regular_file(path);
 }
 
 inline bool FolderExists(const std::string& path) {
-  std::string platformPath = ConvertToPlatformPath(path);
+  std::filesystem::path platformPath = ConvertToPlatformPath(path);
   return std::filesystem::exists(platformPath) && std::filesystem::is_directory(platformPath);
 }
 
 inline std::string getFolder(const std::string& path) {
-  return std::filesystem::path(ConvertToPlatformPath(path)).parent_path().string();
+  return ConvertToPlatformPath(path).parent_path().string();
 }
 
 inline std::string GetFileName(const std::string& filePath) {
-  return std::filesystem::path(ConvertToPlatformPath(filePath)).filename().string();
+  return ConvertToPlatformPath(filePath).filename().string();
 }
 
 inline std::string GetFileBase(const std::string& filePath) {
-  return std::filesystem::path(ConvertToPlatformPath(filePath)).stem().string();
+  return ConvertToPlatformPath(filePath).stem().string();
 }
 
 inline std::optional<std::string> GetFileSuffix(const std::string& filePath) {
-  std::string platformPath = ConvertToPlatformPath(filePath);
+  std::filesystem::path platformPath = ConvertToPlatformPath(filePath);
 
-  const auto& extension = std::filesystem::path(platformPath).extension();
+  const auto& extension = platformPath.extension();
   if (extension.empty()) {
     return std::nullopt;
   }

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -56,12 +56,14 @@ inline std::string GetCurrentFolder() {
 
 inline bool FileExists(const std::string& filePath) {
   std::filesystem::path path = ConvertToPlatformPath(filePath);
-  return std::filesystem::exists(path) && std::filesystem::is_regular_file(path);
+  std::error_code errorCode;
+  return std::filesystem::exists(path, errorCode) && std::filesystem::is_regular_file(path, errorCode);
 }
 
 inline bool FolderExists(const std::string& path) {
   std::filesystem::path platformPath = ConvertToPlatformPath(path);
-  return std::filesystem::exists(platformPath) && std::filesystem::is_directory(platformPath);
+  std::error_code errorCode;
+  return std::filesystem::exists(platformPath, errorCode) && std::filesystem::is_directory(platformPath, errorCode);
 }
 
 inline std::string getFolder(const std::string& path) {

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -32,6 +32,8 @@ bool CopyFile(
     const std::string& dstFilename,
     bool createPath = false);
 
+std::filesystem::path ConvertToPlatformPath(const std::string& path);
+
 inline std::string NormalizePath(const std::string& path) {
 #ifdef __APPLE__
     std::string normalizedPath = path;
@@ -43,8 +45,9 @@ inline std::string NormalizePath(const std::string& path) {
 }
 
 inline std::string GetAbsolutePath(const std::string& filePath) {
-  std::string normalizedFilePath = NormalizePath(filePath);
-  return std::filesystem::absolute(normalizedFilePath).string();
+  std::string normalizedPath = NormalizePath(filePath);
+  std::filesystem::path absolutePath = std::filesystem::absolute(ConvertToPlatformPath(normalizedPath));
+  return absolutePath.string();
 }
 
 inline std::string GetCurrentFolder() {
@@ -52,32 +55,37 @@ inline std::string GetCurrentFolder() {
 }
 
 inline bool FileExists(const std::string& filePath) {
-  std::string normalizedFilePath = NormalizePath(filePath);
-  return std::filesystem::exists(normalizedFilePath) && std::filesystem::is_regular_file(normalizedFilePath);
+  std::string normalizedPath = NormalizePath(filePath);
+  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+  return std::filesystem::exists(platformPath) && std::filesystem::is_regular_file(platformPath);
 }
 
-inline bool FolderExists(const std::string& folderPath) {
-  std::string normalizedFolderPath = NormalizePath(folderPath);
-  return std::filesystem::exists(normalizedFolderPath) && std::filesystem::is_directory(normalizedFolderPath);
+inline bool FolderExists(const std::string& path) {
+  std::string normalizedPath = NormalizePath(path);
+  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+  return std::filesystem::exists(platformPath) && std::filesystem::is_directory(platformPath);
 }
 
 inline std::string getFolder(const std::string& path) {
   std::string normalizedPath = NormalizePath(path);
-  return std::filesystem::path(normalizedPath).parent_path().string();
+  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).parent_path().string();
 }
 
-inline std::string GetFileName(const std::string& path) {
-  std::string normalizedPath = NormalizePath(path);
-  return std::filesystem::path(normalizedPath).filename().string();
+inline std::string GetFileName(const std::string& filePath) {
+  std::string normalizedPath = NormalizePath(filePath);
+  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).filename().string();
 }
 
-inline std::string GetFileBase(const std::string& path) {
-  std::string normalizedPath = NormalizePath(path);
-  return std::filesystem::path(normalizedPath).stem().string();
+inline std::string GetFileBase(const std::string& filePath) {
+  std::string normalizedPath = NormalizePath(filePath);
+  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).stem().string();
 }
 
-inline std::optional<std::string> GetFileSuffix(const std::string& path) {
-  const auto& extension = std::filesystem::path(path).extension();
+inline std::optional<std::string> GetFileSuffix(const std::string& filePath) {
+  std::string normalizedPath = NormalizePath(filePath);
+  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+
+  const auto& extension = std::filesystem::path(platformPath).extension();
   if (extension.empty()) {
     return std::nullopt;
   }

--- a/src/utils/File_Utils.hpp
+++ b/src/utils/File_Utils.hpp
@@ -45,8 +45,7 @@ inline std::string NormalizePath(const std::string& path) {
 }
 
 inline std::string GetAbsolutePath(const std::string& filePath) {
-  std::string normalizedPath = NormalizePath(filePath);
-  std::filesystem::path absolutePath = std::filesystem::absolute(ConvertToPlatformPath(normalizedPath));
+  std::filesystem::path absolutePath = std::filesystem::absolute(ConvertToPlatformPath(filePath));
   return absolutePath.string();
 }
 
@@ -55,35 +54,29 @@ inline std::string GetCurrentFolder() {
 }
 
 inline bool FileExists(const std::string& filePath) {
-  std::string normalizedPath = NormalizePath(filePath);
-  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+  std::string platformPath = ConvertToPlatformPath(filePath);
   return std::filesystem::exists(platformPath) && std::filesystem::is_regular_file(platformPath);
 }
 
 inline bool FolderExists(const std::string& path) {
-  std::string normalizedPath = NormalizePath(path);
-  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+  std::string platformPath = ConvertToPlatformPath(path);
   return std::filesystem::exists(platformPath) && std::filesystem::is_directory(platformPath);
 }
 
 inline std::string getFolder(const std::string& path) {
-  std::string normalizedPath = NormalizePath(path);
-  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).parent_path().string();
+  return std::filesystem::path(ConvertToPlatformPath(path)).parent_path().string();
 }
 
 inline std::string GetFileName(const std::string& filePath) {
-  std::string normalizedPath = NormalizePath(filePath);
-  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).filename().string();
+  return std::filesystem::path(ConvertToPlatformPath(filePath)).filename().string();
 }
 
 inline std::string GetFileBase(const std::string& filePath) {
-  std::string normalizedPath = NormalizePath(filePath);
-  return std::filesystem::path(ConvertToPlatformPath(normalizedPath)).stem().string();
+  return std::filesystem::path(ConvertToPlatformPath(filePath)).stem().string();
 }
 
 inline std::optional<std::string> GetFileSuffix(const std::string& filePath) {
-  std::string normalizedPath = NormalizePath(filePath);
-  std::string platformPath = ConvertToPlatformPath(normalizedPath);
+  std::string platformPath = ConvertToPlatformPath(filePath);
 
   const auto& extension = std::filesystem::path(platformPath).extension();
   if (extension.empty()) {


### PR DESCRIPTION
Some of std::filsystem functions need to accept an error code, or it will throw an exception if having some error. For example, if passing a non utf-8 string to `std::filesystem::exists(path)` and not use error code, then it will throw an exception.